### PR TITLE
Enhance landing with Strava-themed layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Navbar from "@/src/components/Navbar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <Navbar />
         {children}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,46 @@
 import StravaLoginButton from "@/src/components/StravaLoginButton";
 
+const features = [
+  {
+    title: "Elige tu mejor actividad",
+    text: "Conecta con Strava y selecciona la ruta que quieras enmarcar.",
+  },
+  {
+    title: "Personaliza el diseño",
+    text: "Ajusta colores y detalles para crear un recuerdo único.",
+  },
+  {
+    title: "Recibe tu cuadro impreso",
+    text: "Enviamos tu recorrido listo para colgar en la pared.",
+  },
+];
+
 export default function Home() {
   return (
-    <main className="flex min-h-screen items-center justify-center p-8">
-      <StravaLoginButton />
+    <main>
+      <section className="bg-orange-500 text-white py-24 px-6 text-center">
+        <h1 className="text-4xl font-bold mb-4">
+          Convierte tus rutas de Strava en arte
+        </h1>
+        <p className="mb-8 text-lg">
+          Crea cuadros impresos con tus recorridos y revive cada kilómetro.
+        </p>
+        <StravaLoginButton />
+      </section>
+
+      <section className="py-16 px-6 max-w-4xl mx-auto grid gap-8 md:grid-cols-3">
+        {features.map((f) => (
+          <div key={f.title} className="text-center">
+            <h3 className="text-xl font-semibold mb-2">{f.title}</h3>
+            <p className="text-gray-700 dark:text-gray-300">{f.text}</p>
+          </div>
+        ))}
+      </section>
+
+      <section className="bg-gray-100 dark:bg-gray-900 py-12 px-6 text-center">
+        <h2 className="text-2xl font-bold mb-4">¿Listo para empezar?</h2>
+        <StravaLoginButton />
+      </section>
     </main>
   );
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,10 @@
+import StravaLoginButton from "@/src/components/StravaLoginButton";
+
+export default function Navbar() {
+  return (
+    <nav className="flex items-center justify-between px-6 py-4 bg-orange-500 text-white">
+      <div className="text-lg font-bold">Frava</div>
+      <StravaLoginButton />
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- create Navbar component using Strava colors
- include Navbar in layout
- redesign homepage with Strava-inspired hero and features

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686457fe914083288f3c48762dce237e