### PR TITLE
Implement athlete profile and improved activity page

### DIFF
--- a/app/activities/[id]/page.tsx
+++ b/app/activities/[id]/page.tsx
@@ -45,21 +45,45 @@ export default function ActivityDetailPage() {
   if (!activity) return <p className="p-6">Cargando actividad...</p>;
 
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold mb-4">{activity.name}</h1>
-      <p>Tipo: {activity.type}</p>
-      <p>Distancia: {(activity.distance / 1000).toFixed(2)} km</p>
-      <p>Duración: {(activity.moving_time / 60).toFixed(0)} min</p>
-      <p>Elevación: {activity.total_elevation_gain} m</p>
-      <p>Fecha: {new Date(activity.start_date).toLocaleString()}</p>
+    <div className="p-6 max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold mb-2">{activity.name}</h1>
+      <p className="text-gray-500 mb-4">
+        {new Date(activity.start_date).toLocaleString()}
+      </p>
 
       {activity.map?.summary_polyline && (
+        <div className="mb-6">
+          <StravaMap encodedPolyline={activity.map.summary_polyline} />
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 bg-white rounded shadow text-center py-4">
         <div>
-        <StravaMap encodedPolyline={activity.map.summary_polyline} />
+          <div className="text-xl font-bold">
+            {(activity.distance / 1000).toFixed(2)} km
+          </div>
+          <div className="text-sm text-gray-500">Distancia</div>
+        </div>
+        <div>
+          <div className="text-xl font-bold">
+            {(activity.moving_time / 60).toFixed(0)} min
+          </div>
+          <div className="text-sm text-gray-500">Tiempo</div>
+        </div>
+        <div>
+          <div className="text-xl font-bold">{activity.total_elevation_gain} m</div>
+          <div className="text-sm text-gray-500">Elevación</div>
+        </div>
+        <div>
+          <div className="text-xl font-bold">{activity.type}</div>
+          <div className="text-sm text-gray-500">Tipo</div>
+        </div>
+      </div>
 
-        <StaticPolylineCanvas encodedPolyline={activity.map.summary_polyline} />
-
-        <CustomStravaTemplate activity={activity} />
+      {activity.map?.summary_polyline && (
+        <div className="mt-8 space-y-8">
+          <StaticPolylineCanvas encodedPolyline={activity.map.summary_polyline} />
+          <CustomStravaTemplate activity={activity} />
         </div>
       )}
     </div>

--- a/app/api/strava/athlete/route.ts
+++ b/app/api/strava/athlete/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const token = req.cookies.get("strava_token")?.value;
+  if (!token) return NextResponse.json({ error: "No autorizado" }, { status: 401 });
+
+  const res = await fetch("https://www.strava.com/api/v3/athlete", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    return NextResponse.json({ error: "Strava API error", details: data }, { status: res.status });
+  }
+  return NextResponse.json({ athlete: data });
+}
+
+export async function PUT(req: NextRequest) {
+  const token = req.cookies.get("strava_token")?.value;
+  if (!token) return NextResponse.json({ error: "No autorizado" }, { status: 401 });
+
+  const body = await req.json().catch(() => ({}));
+  const res = await fetch("https://www.strava.com/api/v3/athlete", {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    return NextResponse.json({ error: "Strava API error", details: data }, { status: res.status });
+  }
+  return NextResponse.json({ athlete: data });
+}

--- a/app/api/strava/logout/route.ts
+++ b/app/api/strava/logout/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  return NextResponse.redirect(new URL("/", req.url), {
+    headers: {
+      "Set-Cookie": "strava_token=; Path=/; Max-Age=0",
+    },
+  });
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+import { useEffect, useState } from "react";
+
+interface Athlete {
+  weight?: number;
+}
+
+export default function Profile() {
+  const [weight, setWeight] = useState<string>("");
+  const [message, setMessage] = useState<string>("");
+
+  useEffect(() => {
+    fetch("/api/strava/athlete")
+      .then((res) => res.ok ? res.json() : null)
+      .then((data) => {
+        if (data?.athlete?.weight) setWeight(String(data.athlete.weight));
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    fetch("/api/strava/athlete", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ weight: parseFloat(weight) }),
+    })
+      .then((res) => res.ok ? res.json() : Promise.reject(res))
+      .then(() => setMessage("Actualizado"))
+      .catch(() => setMessage("Error al actualizar"));
+  };
+
+  return (
+    <div className="p-6 max-w-md mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Tu Perfil</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block mb-1">Peso (kg)</label>
+          <input
+            type="number"
+            value={weight}
+            onChange={(e) => setWeight(e.target.value)}
+            className="border rounded px-3 py-2 w-full"
+          />
+        </div>
+        <button type="submit" className="px-4 py-2 bg-orange-500 text-white rounded">
+          Guardar
+        </button>
+      </form>
+      {message && <p className="mt-4">{message}</p>}
+    </div>
+  );
+}

--- a/lib/strava.ts
+++ b/lib/strava.ts
@@ -28,3 +28,24 @@ export async function fetchActivity(id: string, token: string) {
   if (!res.ok) throw new Error('Failed to load activity');
   return res.json();
 }
+
+export async function fetchAthlete(token: string) {
+  const res = await fetch('https://www.strava.com/api/v3/athlete', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error('Failed to load athlete');
+  return res.json();
+}
+
+export async function updateAthlete(token: string, body: any) {
+  const res = await fetch('https://www.strava.com/api/v3/athlete', {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error('Failed to update athlete');
+  return res.json();
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,10 +1,76 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import StravaLoginButton from "@/src/components/StravaLoginButton";
 
+interface Athlete {
+  firstname: string;
+  lastname: string;
+  profile: string;
+}
+
 export default function Navbar() {
+  const [athlete, setAthlete] = useState<Athlete | null>(null);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/strava/athlete")
+      .then((res) => res.ok ? res.json() : null)
+      .then((data) => {
+        if (data?.athlete) setAthlete(data.athlete);
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleLogout = () => {
+    fetch("/api/strava/logout", { method: "POST" }).then(() => {
+      setAthlete(null);
+      setOpen(false);
+      window.location.href = "/";
+    });
+  };
+
   return (
     <nav className="flex items-center justify-between px-6 py-4 bg-orange-500 text-white">
       <div className="text-lg font-bold">Frava</div>
-      <StravaLoginButton />
+      {athlete ? (
+        <div className="relative">
+          <button
+            onClick={() => setOpen((o) => !o)}
+            className="flex items-center space-x-2 focus:outline-none"
+          >
+            <img
+              src={athlete.profile}
+              alt="profile"
+              className="w-8 h-8 rounded-full border"
+            />
+            <span>{athlete.firstname} {athlete.lastname}</span>
+          </button>
+          {open && (
+            <ul className="absolute right-0 mt-2 w-40 bg-white text-black rounded shadow">
+              <li>
+                <a
+                  href="/profile"
+                  className="block px-4 py-2 hover:bg-gray-100"
+                  onClick={() => setOpen(false)}
+                >
+                  Perfil
+                </a>
+              </li>
+              <li>
+                <button
+                  className="w-full text-left px-4 py-2 hover:bg-gray-100"
+                  onClick={handleLogout}
+                >
+                  Logout
+                </button>
+              </li>
+            </ul>
+          )}
+        </div>
+      ) : (
+        <StravaLoginButton />
+      )}
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- show logged in athlete info with dropdown in Navbar
- add Strava athlete API routes and logout route
- implement a profile page to update weight
- redesign activity detail page similar to Strava

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68645d4e41c48328b3b8852c72299a72